### PR TITLE
Updated mousedown hide method

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -422,7 +422,7 @@
 							this.picker.is(e.target) ||
 							this.picker.find(e.target).length
 						)){
-							$(this.picker).hide();
+							this.hide();
 						}
 					}, this)
 				}]


### PR DESCRIPTION
It was using jQuery's hide method to hide the picker, while the Datepicker's hide method was probably intended.
